### PR TITLE
Rename to Yesterday's Weather / yesterdays-weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yesterday's weather
+# Yesterday's Weather
 
 어제의 기온과 오늘의 기온을 나란히 보여주는 극단적 미니멀 날씨 웹.
 
@@ -52,11 +52,7 @@ fly deploy
 
 ## TODO
 
-- [ ] 커스텀 도메인
-- [ ] Product Hunt 런칭
-- [x] 공유 기능: "yesterday's weather" 클릭 → 모바일 navigator.share / PC 클립보드 복사 (2026-02-11)
-- [x] OG 이미지 PNG 변환: @resvg/resvg-js로 SVG→PNG 변환, 전 플랫폼 호환 (2026-02-11)
-- [x] 소셜 메타태그 강화: twitter:card→summary_large_image, 절대 URL, og:url 추가, 모달 ESC 키 지원 (2026-02-11)
+→ [GitHub Issues](https://github.com/80x24/yesterdays-weather/issues) + [80x24 Roadmap](https://github.com/users/80x24/projects/3)
 
 ## 마케팅
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "yesterday-weather"
+app = "yesterdays-weather"
 primary_region = "nrt"
 
 [build]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yesterday-weather",
+  "name": "yesterdays-weather",
   "version": "0.1.0",
   "description": "어제의 날씨 - 미니멀 날씨 기록 웹",
   "module": "src/index.ts",

--- a/public/index.html
+++ b/public/index.html
@@ -18,15 +18,15 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png">
 
   <!-- OG Tags -->
-  <meta property="og:title" content="어제의 날씨 — yesterday's weather">
+  <meta property="og:title" content="어제의 날씨 — Yesterday's Weather">
   <meta property="og:description" content="어제보다 오늘이 더 춥나? 어제와 오늘의 기온을 나란히 비교하는 미니멀 날씨 웹">
-  <meta property="og:image" content="https://yesterday-weather.fly.dev/og">
-  <meta property="og:url" content="https://yesterday-weather.fly.dev">
+  <meta property="og:image" content="https://yesterdays-weather.80x24.ai/og">
+  <meta property="og:url" content="https://yesterdays-weather.80x24.ai">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="어제의 날씨 — yesterday's weather">
+  <meta name="twitter:title" content="어제의 날씨 — Yesterday's Weather">
   <meta name="twitter:description" content="어제보다 오늘이 더 춥나?">
-  <meta name="twitter:image" content="https://yesterday-weather.fly.dev/og">
+  <meta name="twitter:image" content="https://yesterdays-weather.80x24.ai/og">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -361,7 +361,7 @@
             <div class="temp-diff" @click="toggleUnit()"
                  x-text="tempDiffText()"></div>
 
-            <div class="branding" @click="shareWeather()">yesterday's weather</div>
+            <div class="branding" @click="shareWeather()">Yesterday's Weather</div>
           </div>
         </template>
       </div>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'yesterday-weather-v7'
+const CACHE_NAME = 'yesterdays-weather-v1'
 const ASSETS = [
   '/',
   '/manifest.json',

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ app.get('/og', async (c) => {
       <text x="900" y="340" font-family="system-ui,sans-serif" font-size="160" fill="#fff" font-weight="700" text-anchor="middle" letter-spacing="-4">${currentTemp}°</text>
       <circle cx="600" cy="280" r="4" fill="rgba(255,255,255,0.2)"/>
       <text x="600" y="460" font-family="system-ui,sans-serif" font-size="32" fill="rgba(255,255,255,0.5)" font-weight="400" text-anchor="middle">${diffText} than yesterday</text>
-      <text x="600" y="570" font-family="system-ui,sans-serif" font-size="22" fill="rgba(255,255,255,0.15)" font-weight="300" text-anchor="middle" letter-spacing="6">yesterday's weather</text>
+      <text x="600" y="570" font-family="system-ui,sans-serif" font-size="22" fill="rgba(255,255,255,0.15)" font-weight="300" text-anchor="middle" letter-spacing="6">Yesterday's Weather</text>
     </svg>`
 
     const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } })
@@ -151,7 +151,7 @@ app.get('/og', async (c) => {
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
       <rect width="1200" height="630" fill="#1a1a2e"/>
       <text x="600" y="300" font-family="system-ui,sans-serif" font-size="64" fill="#fff" font-weight="700" text-anchor="middle">어제의 날씨</text>
-      <text x="600" y="380" font-family="system-ui,sans-serif" font-size="28" fill="rgba(255,255,255,0.5)" font-weight="300" text-anchor="middle" letter-spacing="6">yesterday's weather</text>
+      <text x="600" y="380" font-family="system-ui,sans-serif" font-size="28" fill="rgba(255,255,255,0.5)" font-weight="300" text-anchor="middle" letter-spacing="6">Yesterday's Weather</text>
     </svg>`
     const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } })
     const png = resvg.render().asPng()


### PR DESCRIPTION
## Summary

- 영어 공식명: **Yesterday's Weather** (기존 소문자 `yesterday's weather`에서 변경)
- 한국어 공식명: **어제의 날씨** (유지), SEO: **어제 날씨**
- 슬러그/도메인: **yesterdays-weather** (기존 `yesterday-weather`에서 변경)
- 모든 OG/Twitter 메타 URL을 `yesterdays-weather.80x24.ai`로 변경
- Service worker 캐시 이름 리셋 (`yesterdays-weather-v1`)
- `fly.toml` 앱 이름을 `yesterdays-weather`로 변경

## 변경 파일 (6개)

| 파일 | 변경 내용 |
|------|----------|
| `package.json` | name → `yesterdays-weather` |
| `fly.toml` | app → `yesterdays-weather` |
| `public/index.html` | OG/Twitter 메타, 브랜딩 텍스트 |
| `public/sw.js` | 캐시 이름 |
| `src/index.ts` | OG 이미지 SVG 텍스트 |
| `README.md` | 제목, GitHub Issues URL |

## 머지 후 추가 작업 필요

- [ ] **GitHub 리포 이름 변경**: `gh repo rename yesterdays-weather --repo 80x24/yesterday-weather --yes`
- [ ] **Fly.io 앱 생성**: `fly apps create yesterdays-weather` → `fly deploy --now`
- [ ] **Cloudflare DNS**: `yesterdays-weather` CNAME → `yesterdays-weather.fly.dev` (Proxy OFF)
- [ ] **Fly.io 인증서**: `fly certs create yesterdays-weather.80x24.ai -a yesterdays-weather`
- [ ] **기존 Fly.io 앱 정리**: `fly apps destroy yesterday-weather` (새 앱 확인 후)

## Test plan

- [ ] `bun run dev`로 로컬 실행 확인
- [ ] OG 이미지 `/og` 엔드포인트 텍스트 확인
- [ ] 브랜딩 텍스트 "Yesterday's Weather" 표시 확인
- [ ] Service worker 캐시 이름 변경 확인

Closes #2 의 이름 변경 부분

🤖 Generated with [Claude Code](https://claude.com/claude-code)